### PR TITLE
fix(api): explicitly set content encoding to avoid being blocked by gateway

### DIFF
--- a/packages/api/src/routes/connector.ts
+++ b/packages/api/src/routes/connector.ts
@@ -343,8 +343,6 @@ async function execute(ctx: Context) {
     await connectorService.cancelQuery(manager, identifier)
   })
 
-  ctx.type = 'application/json'
-
   await withKeepaliveStream(ctx, async (streamResponse) => {
     const queryResultStream = await connectorService.executeSql(
       manager,

--- a/packages/api/src/utils/stream.ts
+++ b/packages/api/src/utils/stream.ts
@@ -22,7 +22,11 @@ export async function withKeepaliveStream(
 ) {
   const streamResponse = new PassThrough()
 
-  ctx.headers['Content-Type'] = 'application/json;charset=utf8'
+  ctx.type = 'application/json'
+  ctx.set({
+    'Cache-Control': 'no-cache',
+    'Content-Encoding': 'identity',
+  })
   ctx.body = streamResponse
 
   const keepAlive = setInterval(() => {


### PR DESCRIPTION
Background: the `executeSql` endpoint does not act in the way we desired.  

For time-consuming queries, It would be blocked and then closed by our gateway (because of the 60s timeout of our load balancer), which is abnormal since by our design it would response a blank line each 5s to keep the connection alive.

By investigation, our gateway (for some reason) is assumed to block the response by itself to compress it (since the response from our gateway has `Content-Encoding` of gzip.

By explicitly set `Content-Encoding` to `identity`, this issue has been resolved.