### PR TITLE
refactor: remove file watcher

### DIFF
--- a/packages/connector/server/build.gradle.kts
+++ b/packages/connector/server/build.gradle.kts
@@ -56,8 +56,6 @@ dependencies {
     implementation("com.github.marcoferrer.krotoplus:kroto-plus-message:$krotoplusVersion")
     implementation("com.github.marcoferrer.krotoplus:kroto-plus-test:$krotoplusVersion")
     implementation("com.google.protobuf:protobuf-java:$protobufVersion")
-
-    implementation("com.github.vishna:watchservice-ktx:master-SNAPSHOT")
 }
 
 


### PR DESCRIPTION
Currently, the docker image of the connector is not able to be running in M1 Macbooks.

By investigation, the problem was the file watcher.

It has been used for _potentially_ HA deployment of the connector, which in our design should mount the same profile file to multi connectors. In such a setting, the file watcher will watch the change of profile (since the request will be only sent into one of those connectors), and reload the difference.

But after careful consideration, we think that the current design of HA got an inherent flaw: It asks users to mount a single profile file into multiple pods. The best practice in k8s would be creating an opaque secret mounted as a file. But such a file is read-only. 

At the same time, since the implementation of the connector does not ask for high availability currently, we decided to remove the file watcher, and suggest users that only deploy one instance of the connector.

The HA implementation will be on our roadmap but not with high priority.