### PR TITLE
chore: add metric block

### DIFF
--- a/packages/api/src/core/block/init.ts
+++ b/packages/api/src/core/block/init.ts
@@ -37,6 +37,7 @@ import { TweetBlock } from './tweet'
 import { VideoBlock } from './video'
 import { QuestionReferenceBlock } from './questionReference'
 import { YouTubeBlock } from './youtube'
+import { MetricBlock } from './metric'
 
 
 
@@ -56,6 +57,7 @@ const blockConstructors = {
   [BlockType.STORY]: StoryBlock,
   [BlockType.EMBED]: FigmaBlock,
   [BlockType.QUESTION]: QuestionBlock,
+  [BlockType.METRIC]: MetricBlock,
   [BlockType.QUOTE]: QuoteBlock,
   [BlockType.TABLE]: TableBlock,
   [BlockType.TEXT]: TextBlock,

--- a/packages/api/src/core/block/metric.ts
+++ b/packages/api/src/core/block/metric.ts
@@ -1,0 +1,10 @@
+import { BlockType } from '../../types/block'
+import { QuestionBlock } from './question'
+
+export class MetricBlock extends QuestionBlock {
+  static type = BlockType.METRIC
+
+  getType(): BlockType {
+    return MetricBlock.type
+  }
+}

--- a/packages/api/src/core/block/operation.ts
+++ b/packages/api/src/core/block/operation.ts
@@ -52,6 +52,7 @@ export class BlockOperation extends DefaultOperation {
   }
 
   async update(block: Block, args: any, path: string[]): Promise<Block> {
+    
     if (this.isUpdateType(path)) {
       return this.updateType(args, block)
     }

--- a/packages/api/src/types/block.ts
+++ b/packages/api/src/types/block.ts
@@ -14,6 +14,7 @@ enum BlockType {
   NUMBERED_LIST = 'numbered_list',
   STORY = 'story',
   QUESTION = 'question',
+  METRIC = 'metric',
   QUOTE = 'quote',
   TABLE = 'table',
   TEXT = 'text',


### PR DESCRIPTION
now `metric` block extends `question` block

clients can use `/saveTransactions { "args": "metric", "path": "type" }` converting `question` blocks to `metric` blocks
 