### PR TITLE
chore: add anonymous user service

### DIFF
--- a/packages/api/src/core/workspace/index.ts
+++ b/packages/api/src/core/workspace/index.ts
@@ -52,26 +52,28 @@ export class Workspace extends Common {
     return entity
   }
 
-  toDTO(userId: string): WorkspaceDTO {
+  toDTO(userId?: string): WorkspaceDTO {
     const me = _(this.members).find((m) => m.userId === userId)
-    if (!me) {
+    if (!me && userId) {
       throw NoPermissionsError.new()
     }
-    const isAdmin = me.role === PermissionWorkspaceRole.ADMIN
+    const isAdmin = me?.role === PermissionWorkspaceRole.ADMIN
     // sort by joinAt desc
     const sortedMembers = _(this.members)
       .filter((m) => m.userId !== userId)
       .orderBy('joinAt', 'desc')
       .value()
     // push current user to the first
-    sortedMembers.unshift(me)
+    if (me) {
+      sortedMembers.unshift(me)
+    }
     return {
       id: this.id,
       name: this.name,
       avatar: this.avatar,
       members: sortedMembers,
       memberNum: this.members.length,
-      inviteLink: isAdmin ? this.getInviteLink(userId) : undefined,
+      inviteLink: isAdmin && userId ? this.getInviteLink(userId) : undefined,
       preferences: this.preferences,
       createdAt: this.createdAt?.getTime() || 0,
     }

--- a/packages/api/src/middlewares/user.ts
+++ b/packages/api/src/middlewares/user.ts
@@ -7,7 +7,7 @@ import { USER_TOKEN_HEADER_KEY } from '../utils/user'
 const ignorePaths = ['/api/users/login']
 
 // 15 days
-const d15 = 3600 * 24 * 15
+const d15 = 1000 * 3600 * 24 * 15
 
 export default async function user(ctx: Context, next: Next) {
   const token = ctx.headers[USER_TOKEN_HEADER_KEY] || ctx.cookies.get(USER_TOKEN_HEADER_KEY)

--- a/packages/api/src/services/user.ts
+++ b/packages/api/src/services/user.ts
@@ -5,16 +5,13 @@ import { EntityManager, getConnection, getRepository, In } from 'typeorm'
 
 import { User } from '../core/user'
 import { UserEntity } from '../entities/user'
-import { WorkspaceEntity } from '../entities/workspace'
 import { InvalidArgumentError, UnauthorizedError } from '../error/error'
-import { PermissionWorkspaceRole } from '../types/permission'
 import { AccountStatus, UserInfoDTO } from '../types/user'
 import { getSecretKey } from '../utils/common'
 import { decrypt, encrypt } from '../utils/crypto'
 import { isAnonymous } from '../utils/env'
 import { md5 } from '../utils/helper'
 import emailService from './email'
-import workspaceService from './workspace'
 
 type TokenPayload = {
   userId: string
@@ -23,7 +20,7 @@ type TokenPayload = {
 }
 
 export class UserService {
-  protected secretKey: string
+  private secretKey: string
 
   private compatible: boolean
 

--- a/packages/api/src/services/user.ts
+++ b/packages/api/src/services/user.ts
@@ -9,6 +9,7 @@ import { InvalidArgumentError, UnauthorizedError } from '../error/error'
 import { AccountStatus, UserInfoDTO } from '../types/user'
 import { getSecretKey } from '../utils/common'
 import { decrypt, encrypt } from '../utils/crypto'
+import { isAnonymous } from '../utils/env'
 import { md5 } from '../utils/helper'
 import emailService from './email'
 
@@ -202,6 +203,8 @@ export class AnonymousUserService extends UserService {
    * @returns
    */
   async verifyToken(token: string): Promise<{ userId: string; expiresAt: number }> {
+    console.log('ANONYMOUS ....................');
+    
     return super.verifyToken(token).catch(async (err) => {
       console.debug(err)
       const email = this.randomEmail()
@@ -221,7 +224,7 @@ export class AnonymousUserService extends UserService {
   }
 }
 
-const service = process.env.ANONYMOUS ? new AnonymousUserService() : new UserService()
+const service = isAnonymous() ? new AnonymousUserService() : new UserService()
 export default service
 
 /**

--- a/packages/api/src/services/user.ts
+++ b/packages/api/src/services/user.ts
@@ -217,7 +217,7 @@ export class AnonymousUserService extends UserService {
   }
 
   private randomEmail(): string {
-    return `${nanoid()}@tellery-anonymous.io`
+    return `${nanoid()}@tellery.demo`
   }
 }
 

--- a/packages/api/src/services/workspace.ts
+++ b/packages/api/src/services/workspace.ts
@@ -351,10 +351,11 @@ export class AnonymousWorkspaceService extends WorkspaceService {
   }
 
   async inviteMembers(
-    _operatorId: string,
+    operatorId: string, // only for permission validation
     workspaceId: string,
     users: { email: string; role: PermissionWorkspaceRole }[],
   ): Promise<{ workspace: WorkspaceDTO; linkPairs: { [k: string]: string } }> {
+    await canUpdateWorkspaceData(this.permission, operatorId, workspaceId)
     const emails = _(users).map('email').value()
 
     return getConnection().transaction(async (t) => {

--- a/packages/api/src/utils/env.ts
+++ b/packages/api/src/utils/env.ts
@@ -1,3 +1,7 @@
 export function isTest() {
   return process.env.NODE_ENV === 'test'
 }
+
+export function isAnonymous() {
+  return !!process.env.ANONYMOUS
+}

--- a/packages/api/tests/services/anonymousUser.test.ts
+++ b/packages/api/tests/services/anonymousUser.test.ts
@@ -1,0 +1,17 @@
+import test from 'ava'
+import _ from 'lodash'
+
+import { createDatabaseCon } from '../../src/clients/db/orm'
+import { AnonymousUserService } from '../../src/services/user'
+
+const userService = new AnonymousUserService()
+test.before(async () => {
+  await createDatabaseCon()
+})
+
+test('anonymous verifying token', async (t) => {
+  const { userId, expiresAt } = await userService.verifyToken('invalid')
+
+  t.not(userId, undefined)
+  t.is(expiresAt - _.now() < 3600 * 1000 + 1, true)
+})

--- a/packages/api/tests/services/workspace.test.ts
+++ b/packages/api/tests/services/workspace.test.ts
@@ -4,13 +4,13 @@ import { nanoid } from 'nanoid'
 import { getRepository, In } from 'typeorm'
 
 import { createDatabaseCon } from '../../src/clients/db/orm'
-import { FakePermission } from '../../src/core/permission'
+import { FakePermission, getIPermission } from '../../src/core/permission'
 import { Workspace } from '../../src/core/workspace'
 import { UserEntity } from '../../src/entities/user'
 import { WorkspaceEntity } from '../../src/entities/workspace'
 import { WorkspaceMemberEntity } from '../../src/entities/workspaceMember'
 import { WorkspaceViewEntity } from '../../src/entities/workspaceView'
-import { WorkspaceService } from '../../src/services/workspace'
+import { WorkspaceService, AnonymousWorkspaceService } from '../../src/services/workspace'
 import { PermissionWorkspaceRole } from '../../src/types/permission'
 import { AccountStatus } from '../../src/types/user'
 import { WorkspaceDTO, WorkspaceMemberStatus } from '../../src/types/workspace'
@@ -242,6 +242,18 @@ test('getWorkspaceViewByViewId', async (t) => {
   await getRepository(WorkspaceViewEntity).delete(view?.id)
 
   t.deepEqual(getViewRes.id, view.id)
+})
+
+test('anonymous inviteMembersWorkspace', async (t) => {
+  const admin = uuid()
+  const [user] = await mockUsers(1)
+  await workspaceService.create(admin, 'test')
+
+  const { id } = await getRepository(WorkspaceEntity).findOneOrFail()
+  const ws = new AnonymousWorkspaceService(new FakePermission())
+  await ws.inviteMembers('admin', id, [{ email: user.email, role: PermissionWorkspaceRole.MEMBER }])
+  await workspaceService.get(user.id, id)
+  t.pass()
 })
 
 function findMember(

--- a/packages/api/tests/services/workspace.test.ts
+++ b/packages/api/tests/services/workspace.test.ts
@@ -251,7 +251,7 @@ test('anonymous inviteMembersWorkspace', async (t) => {
 
   const { id } = await getRepository(WorkspaceEntity).findOneOrFail()
   const ws = new AnonymousWorkspaceService(new FakePermission())
-  await ws.inviteMembers('admin', id, [{ email: user.email, role: PermissionWorkspaceRole.MEMBER }])
+  await ws.inviteMembers(admin, id, [{ email: user.email, role: PermissionWorkspaceRole.MEMBER }])
   await workspaceService.get(user.id, id)
   t.pass()
 })


### PR DESCRIPTION
### Logic related to anonymous users

- If the user does not pass the token verification, a new `user entity` will be generated for him
- The newly created user entity will be automatically added to the first workspace
- In the anonymous user logic, the user cannot create a workspace and voluntarily leave the workspace, and other behaviors are left to permission management