### PR TITLE
move all files / configs governed by this service itself to a single folder

### DIFF
--- a/packages/connector/README.md
+++ b/packages/connector/README.md
@@ -2,9 +2,9 @@
 
 ## Deployment
 
-1. mount your own profile file (see example) to `/usr/app/profiles.json`
+1. mount your own profile file (see example) to `/usr/app/extra/profiles.json`
 
-2. If there is any third-party / community-supported connectors, put its jar into a folder and mount it to `/usr/app/extra`
+2. If there is any third-party / community-supported connectors, put its jar into a folder and mount it to `/usr/app/extra/lib`
 
 3. start the container and enjoy!
 
@@ -12,10 +12,10 @@
 
 ### Bring your own profiles
 
-The default working directory is `$rootProject.workingDir`, so you can put your own `profiles.json` right in this folder.
+The default working directory is `$rootProject.workingDir`, in gradle idea plugin it has been set to `packages/connector`, so you can put your own `profiles.json` right in `packages/connector/extra` if you start the service by idea.
 
 If you want to specify the profile path, you can override it by enviroment variable `PROFILE_PATH` (it should be a path **relative** to the working dir).
 
-If you wanna test on third-party connector, put jars into `workingDir/extra`.
+If you wanna test on third-party connector, put jars into `packages/connector/extra/lib`.
 
 Then you can go with `gradle run`, everything will be all set.

--- a/packages/connector/interface/src/entities/Exceptions.kt
+++ b/packages/connector/interface/src/entities/Exceptions.kt
@@ -10,6 +10,9 @@ class TruncateException : Exception("Truncated")
 class DBProfileNotConfiguredException :
     Exception("DB Profile not configured correctly! Please specify its path in application.conf")
 
+class DBConfigDirOccupiedException(fn: String) :
+    Exception("DB Config Directory $fn has been occupied")
+
 class JDBCDriverClassNotFoundException(profile: String, className: String) :
     Exception("Driver not found for profile $profile, required driver $className")
 

--- a/packages/connector/server/build.gradle.kts
+++ b/packages/connector/server/build.gradle.kts
@@ -115,7 +115,7 @@ tasks.withType<KotlinCompile> {
 
 tasks.withType<JavaExec> {
     workingDir = rootProject.projectDir
-    classpath += files("${rootProject.projectDir}/extra/*")
+    classpath += files("${rootProject.projectDir}/extra/lib/*")
 }
 
 tasks.withType<Jar> {
@@ -143,7 +143,7 @@ jib {
         appRoot = "/usr/app"
         containerizingMode = "packaged"
         workingDirectory = "/usr/app"
-        extraClasspath = listOf("/usr/app/extra/*")
+        extraClasspath = listOf("/usr/app/extra/lib/*")
         jvmFlags = listOf(
             "-server",
             "-Djava.awt.headless=true",

--- a/packages/connector/server/resources/application.conf
+++ b/packages/connector/server/resources/application.conf
@@ -1,3 +1,6 @@
+configDirPath = "extra"
+configDirPath = ${?CONFIG_DIR_PATH}
+
 dbProfile {
   path = "profiles.json"
   path = ${?PROFILE_PATH}

--- a/packages/connector/server/src/common/dbt/Constants.kt
+++ b/packages/connector/server/src/common/dbt/Constants.kt
@@ -32,6 +32,6 @@ object Constants {
     const val SF_USERNAME_FIELD: String = "Username"
     const val SF_PASSWORD_FIELD: String = "Password"
 
-    val EXTERNAL_CONFIG_FIELDS: List<String> =
-        ImmutableList.of(PROFILE_GIT_URL_FIELD, PROFILE_DBT_PROJECT_FIELD)
+    val EXTERNAL_CONFIG_FIELDS: List<String> = listOf(PROFILE_GIT_URL_FIELD, PROFILE_DBT_PROJECT_FIELD)
+
 }

--- a/packages/connector/server/src/common/dbt/ProfileManager.kt
+++ b/packages/connector/server/src/common/dbt/ProfileManager.kt
@@ -12,9 +12,11 @@ object ProfileManager {
     private val mapper = ObjectMapper(YAMLFactory()).registerModule(KotlinModule.Builder().build())
 
     fun batchToDbtProfile(profiles: List<Profile>): String {
-        val profileMap = profiles
-            .map { it.configs[Constants.PROFILE_DBT_PROJECT_FIELD] to Entity(Output(toDbtProfile(it))) }
-            .toMap()
+        val profileMap = profiles.associate {
+            it.configs[Constants.PROFILE_DBT_PROJECT_FIELD] to Entity(
+                Output(toDbtProfile(it))
+            )
+        }
         return mapper.writeValueAsString(profileMap)
     }
 

--- a/packages/connector/server/test/common/dbt/DbtManagerTest.kt
+++ b/packages/connector/server/test/common/dbt/DbtManagerTest.kt
@@ -54,7 +54,7 @@ class DbtManagerTest {
         val manifestFile = File(DbtManagerTest::class.java.getResource("/manifest.json").toURI())
 
         val blocks = DbtManager.parseDbtBlocks(manifestFile)
-        val blockMap = blocks.map { it.name to it }.toMap()
+        val blockMap = blocks.associateBy { it.name }
 
         assertFalse(blockMap.containsKey("model.jaffle_shop.my_first_dbt_model"))
         assertEquals(3, blocks.size)


### PR DESCRIPTION
move `profiles.json` from `$workingDir/profiles.json` to `$workingDir/extra/json`
move `dbt` , `dbt_key` to `extra/dbt`, `extra/dbt_key`
move third party libs from `extra` to `extra/lib`

Background: for mounting / persisting configs / user generated files easier.