### PR TITLE
fix: just transform valid profile(can pass dbt profile checker) to dbt profile.

### DIFF
--- a/packages/connector/server/src/common/dbt/ProfileManager.kt
+++ b/packages/connector/server/src/common/dbt/ProfileManager.kt
@@ -3,6 +3,7 @@ package io.tellery.common.dbt
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import io.tellery.common.dbt.DbtManager.isDbtProfile
 import io.tellery.common.dbt.profile.*
 import io.tellery.common.dbt.profile.Entity.Output
 import io.tellery.entities.Profile
@@ -12,11 +13,13 @@ object ProfileManager {
     private val mapper = ObjectMapper(YAMLFactory()).registerModule(KotlinModule.Builder().build())
 
     fun batchToDbtProfile(profiles: List<Profile>): String {
-        val profileMap = profiles.associate {
-            it.configs[Constants.PROFILE_DBT_PROJECT_FIELD] to Entity(
-                Output(toDbtProfile(it))
-            )
-        }
+        val profileMap = profiles
+            .filter { isDbtProfile(it) }
+            .associate {
+                it.configs[Constants.PROFILE_DBT_PROJECT_FIELD] to Entity(
+                    Output(toDbtProfile(it))
+                )
+            }
         return mapper.writeValueAsString(profileMap)
     }
 

--- a/packages/connector/server/testresources/dbt_profiles.json
+++ b/packages/connector/server/testresources/dbt_profiles.json
@@ -7,7 +7,8 @@
       "Region Id": "us-ease-2.aws",
       "Username": "abc",
       "Password": "def",
-      "DbtProjectName": "projectA"
+      "DbtProjectName": "projectA",
+      "GitUrl": "git://xxxx"
     }
   },
   {
@@ -19,7 +20,8 @@
       "Database": "my_db",
       "Username": "abc",
       "Password": "def",
-      "DbtProjectName": "projectB"
+      "DbtProjectName": "projectB",
+      "GitUrl": "git://xxxx"
     }
   },
   {
@@ -31,7 +33,19 @@
       "Database": "my_db",
       "Username": "abc",
       "Password": "def",
-      "DbtProjectName": "projectC"
+      "DbtProjectName": "projectC",
+      "GitUrl": "git://xxxx"
+    }
+  },
+  {
+    "type": "PostgreSQL",
+    "name": "profileD",
+    "configs": {
+      "Endpoint": "127.0.0.1",
+      "Port": "5432",
+      "Database": "my_db",
+      "Username": "abc",
+      "Password": "def"
     }
   }
 ]


### PR DESCRIPTION
This bug will block the initialization of the program with no dbt information profiles.

Stacktrace:
```
2021-07-30 07:09:47.124 [main] INFO  io.tellery.common.ConnectorManager - Loaded Connectors BigQuery, Snowflake, Redshift, PostgreSQL
2021-07-30 07:09:47.472 [main] INFO  io.tellery.ConnectorServer - Credentials has not been setup, starting server in insecure mode
2021-07-30 07:09:47.724 [main] INFO  io.tellery.ConnectorServer - Server started, listening on 50051
2021-07-30 07:11:21.364 [DefaultDispatcher-worker-2] INFO  io.tellery.common.ConnectorManager - initialized profile default; loaded import handler [text/csv]
2021-07-30 07:11:21.596 [DefaultDispatcher-worker-2] ERROR io.tellery.utils.S3Storage - Error when handling upsertProfile
com.fasterxml.jackson.databind.JsonMappingException: Null key for a Map not allowed in JSON (use a converting NullKeySerializer?) (through reference chain: java.util.LinkedHashMap["null"])
        at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:281)
        at com.fasterxml.jackson.databind.SerializerProvider.mappingException(SerializerProvider.java:1336)
        at com.fasterxml.jackson.databind.SerializerProvider.reportMappingProblem(SerializerProvider.java:1230)
        at com.fasterxml.jackson.databind.ser.impl.FailingSerializer.serialize(FailingSerializer.java:32)
        at com.fasterxml.jackson.databind.ser.std.MapSerializer.serializeFields(MapSerializer.java:791)
        at com.fasterxml.jackson.databind.ser.std.MapSerializer.serializeWithoutTypeInfo(MapSerializer.java:764)
        at com.fasterxml.jackson.databind.ser.std.MapSerializer.serialize(MapSerializer.java:720)
        at com.fasterxml.jackson.databind.ser.std.MapSerializer.serialize(MapSerializer.java:35)
        at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._serialize(DefaultSerializerProvider.java:480)
        at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:319)
        at com.fasterxml.jackson.databind.ObjectMapper._writeValueAndClose(ObjectMapper.java:4487)
        at com.fasterxml.jackson.databind.ObjectMapper.writeValueAsString(ObjectMapper.java:3742)
        at io.tellery.common.dbt.ProfileManager.batchToDbtProfile(ProfileManager.kt:20)
        at io.tellery.common.dbt.DbtManager.reloadDbtProfiles(DbtManager.kt:143)
        at io.tellery.services.ConnectorService$upsertProfile$2.invokeSuspend(ConnectorService.kt:135)
        at io.tellery.services.ConnectorService$upsertProfile$2.invoke(ConnectorService.kt)
        at io.tellery.services.ConnectorService$upsertProfile$2.invoke(ConnectorService.kt)
        at io.tellery.common.UtilsKt.withErrorWrapper(Utils.kt:11)
        at io.tellery.services.ConnectorService.upsertProfile(ConnectorService.kt:103)
        at io.tellery.grpc.ConnectorCoroutineGrpc$ConnectorImplBase$ServiceDelegate$upsertProfile$1.invokeSuspend(ConnectorCoroutineGrpc.kt:306)
        at io.tellery.grpc.ConnectorCoroutineGrpc$ConnectorImplBase$ServiceDelegate$upsertProfile$1.invoke(ConnectorCoroutineGrpc.kt)
        at io.tellery.grpc.ConnectorCoroutineGrpc$ConnectorImplBase$ServiceDelegate$upsertProfile$1.invoke(ConnectorCoroutineGrpc.kt)
        at com.github.marcoferrer.krotoplus.coroutines.server.ServerCallsKt$serverCallUnary$$inlined$with$lambda$1.invokeSuspend(ServerCalls.kt:52)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
        Suppressed: org.yaml.snakeyaml.emitter.EmitterException: expected NodeEvent, but got <org.yaml.snakeyaml.events.DocumentEndEvent()>
                at org.yaml.snakeyaml.emitter.Emitter.expectNode(Emitter.java:427)
                at org.yaml.snakeyaml.emitter.Emitter.access$1600(Emitter.java:64)
                at org.yaml.snakeyaml.emitter.Emitter$ExpectBlockMappingKey.expect(Emitter.java:656)
                at org.yaml.snakeyaml.emitter.Emitter$ExpectFirstBlockMappingKey.expect(Emitter.java:633)
                at org.yaml.snakeyaml.emitter.Emitter.emit(Emitter.java:235)
                at com.fasterxml.jackson.dataformat.yaml.YAMLGenerator._emit(YAMLGenerator.java:969)
                at com.fasterxml.jackson.dataformat.yaml.YAMLGenerator._emitEndDocument(YAMLGenerator.java:964)
                at com.fasterxml.jackson.dataformat.yaml.YAMLGenerator.close(YAMLGenerator.java:489)
                at com.fasterxml.jackson.databind.util.ClassUtil.closeOnFailAndThrowAsIOE(ClassUtil.java:497)
                at com.fasterxml.jackson.databind.ObjectMapper._writeValueAndClose(ObjectMapper.java:4489)
                ... 18 common frames omitted
```