### PR TITLE
add api for sql editor completion

### DIFF
--- a/packages/api/src/core/search/interface.ts
+++ b/packages/api/src/core/search/interface.ts
@@ -67,7 +67,7 @@ export type HintData = {
 export enum SearchableResourceType {
   BLOCK = 'block',
   USER = 'user',
-  // internal: this will only search question block's title
+  // internal: this will only search question block's sql
   _QUESTION_BLOCK_SQL = '_question_sql',
 }
 

--- a/packages/api/src/routes/global.ts
+++ b/packages/api/src/routes/global.ts
@@ -194,6 +194,16 @@ async function referenceCompletion(ctx: Context) {
     }
   }
 
+  // fill story blocks
+  const storyBlocks = await blockService.mget(
+    user.id,
+    payload.workspaceId,
+    _(results.blocks).map('storyId').uniq().value(),
+  )
+  _(storyBlocks).forEach((b) => {
+    results.blocks![b.id] = b
+  })
+
   ctx.body = { results }
 }
 

--- a/packages/api/src/routes/global.ts
+++ b/packages/api/src/routes/global.ts
@@ -11,12 +11,13 @@ import linkService from '../services/link'
 import searchService from '../services/search'
 import snapshotService from '../services/snapshot'
 import * as userService from '../services/user'
-import { BlockDTO } from '../types/block'
+import { BlockDTO, BlockType } from '../types/block'
+import { SearchResultDataDTO } from '../types/search'
+import { SnapshotDTO } from '../types/snapshot'
 import { StoryDTO } from '../types/story'
 import { UserInfoDTO } from '../types/user'
 import { validate } from '../utils/http'
 import { mustGetUser } from '../utils/user'
-import { SnapshotDTO } from '../types/snapshot'
 
 export class GlobalSearchRequest {
   @IsDefined()
@@ -148,9 +149,58 @@ async function mgetResources(ctx: Context) {
   ctx.body = res
 }
 
+/**
+ * Automatically complete references to other block in the editor
+ */
+async function referenceCompletion(ctx: Context) {
+  const payload = plainToClass(GlobalSearchRequest, ctx.request.body)
+  await validate(ctx, payload)
+
+  const user = mustGetUser(ctx)
+  const { limit } = payload
+  const types = [BlockType.METRIC, BlockType.QUESTION]
+  const funcs = _(types)
+    .map((t) =>
+      searchService.searchResources(
+        user.id,
+        payload.workspaceId,
+        payload.keyword,
+        [SearchableResourceType.BLOCK],
+        limit,
+        { type: t },
+      ),
+    )
+    .value()
+  const searchedRes = await Promise.all(funcs)
+
+  const rss = _(searchedRes).map('results').value()
+
+  const srs = _(rss).flatMap('searchResults').take(limit).value()
+
+  const results: SearchResultDataDTO = {
+    blocks: {},
+    highlights: {},
+    searchResults: srs,
+  }
+
+  for (const sr of srs) {
+    for (const rs of rss) {
+      if (rs.highlights[sr]) {
+        results.highlights[sr] = rs.highlights[sr]
+      }
+      if (rs.blocks && rs.blocks[sr]) {
+        results.blocks![sr] = rs.blocks[sr]
+      }
+    }
+  }
+
+  ctx.body = { results }
+}
+
 const router = new Router()
 
 router.post('/search', search)
 router.post('/mgetResources', mgetResources)
+router.post('/referenceCompletion', referenceCompletion)
 
 export default router

--- a/packages/api/tests/app.test.ts
+++ b/packages/api/tests/app.test.ts
@@ -825,6 +825,22 @@ test.serial('reference completion', async (t: ExecutionContext<any>) => {
   await getConnection().transaction(async (manager) => {
     const bop = new BlockOperation('test', 'test', manager)
 
+    // create story
+    await set(
+      bop,
+      sid1,
+      {
+        id: sid1,
+        children: [qid, mid1, mid2],
+        type: 'story',
+        content: { title: [[title]] },
+        parentId: 'test',
+        parentTable: 'workspace',
+        storyId: sid1,
+        alive: true,
+      },
+      [],
+    )
     // create question
     await set(
       bop,
@@ -902,6 +918,8 @@ test.serial('reference completion', async (t: ExecutionContext<any>) => {
   t.is(blocks3[srs3[1]].type, 'metric')
   // last one is question block
   t.is(blocks3[srs3[2]].type, 'question')
+  // contains story blocks
+  t.not(blocks3[sid1], undefined)
 
   // not find with title
   const completionRes2: any = await got<any>('api/referenceCompletion', {
@@ -919,6 +937,7 @@ test.serial('reference completion', async (t: ExecutionContext<any>) => {
   // all of them are metric blocks
   t.is(blocks2[srs2[0]].type, 'metric')
   t.is(blocks2[srs2[1]].type, 'metric')
+  t.not(blocks2[sid1], undefined)
 
   await getRepository(BlockEntity).delete([qid, mid1, mid2])
 })

--- a/packages/api/tests/app.test.ts
+++ b/packages/api/tests/app.test.ts
@@ -6,7 +6,7 @@ import _, { random } from 'lodash'
 import { nanoid } from 'nanoid'
 import { Socket } from 'socket.io'
 import { io } from 'socket.io-client'
-import { getConnection } from 'typeorm'
+import { getConnection, getRepository, In } from 'typeorm'
 
 import app from '../src'
 import { createDatabaseCon } from '../src/clients/db/orm'
@@ -810,4 +810,115 @@ test.serial('search question blocks by sql', async (t: ExecutionContext<any>) =>
   }).json()
 
   t.is(searchWithoutSql.results.searchResults.length, 0)
+})
+
+test.serial('reference completion', async (t: ExecutionContext<any>) => {
+  const sid1 = nanoid()
+  const qid = nanoid()
+  const mid1 = nanoid()
+  const mid2 = nanoid()
+  const workspaceId = uuid()
+  // here nanoid() will be word cutting
+  const title = `searchable title`
+  const sql = 'select * from order limit 1'
+
+  await getConnection().transaction(async (manager) => {
+    const bop = new BlockOperation('test', 'test', manager)
+
+    // create question
+    await set(
+      bop,
+      qid,
+      {
+        id: qid,
+        workspaceId,
+        type: BlockType.QUESTION,
+        storyId: sid1,
+        parentId: workspaceId,
+        parentTable: 'workspace',
+        content: {
+          title: [[title]],
+          sql,
+        },
+        alive: true,
+      },
+      [],
+    )
+    // create metrics 1
+    await set(
+      bop,
+      mid1,
+      {
+        id: mid1,
+        workspaceId,
+        type: BlockType.METRIC,
+        storyId: sid1,
+        parentId: workspaceId,
+        parentTable: 'workspace',
+        content: {
+          title: [[title]],
+          sql,
+        },
+        alive: true,
+      },
+      [],
+    )
+    // create metrics 2
+    await set(
+      bop,
+      mid2,
+      {
+        id: mid2,
+        workspaceId,
+        type: BlockType.METRIC,
+        storyId: sid1,
+        parentId: workspaceId,
+        parentTable: 'workspace',
+        content: {
+          title: [[title]],
+          sql,
+        },
+        alive: true,
+      },
+      [],
+    )
+  })
+
+  // not find with title
+  const completionRes3: any = await got<any>('api/referenceCompletion', {
+    prefixUrl: t.context.prefixUrl,
+    method: 'POST',
+    json: {
+      workspaceId,
+      keyword: 'searchable',
+      limit: 3,
+    },
+  }).json()
+  const srs3 = completionRes3.results.searchResults
+  const blocks3 = completionRes3.results.blocks
+  t.is(srs3.length, 3)
+  // first two are metric blocks
+  t.is(blocks3[srs3[0]].type, 'metric')
+  t.is(blocks3[srs3[1]].type, 'metric')
+  // last one is question block
+  t.is(blocks3[srs3[2]].type, 'question')
+
+  // not find with title
+  const completionRes2: any = await got<any>('api/referenceCompletion', {
+    prefixUrl: t.context.prefixUrl,
+    method: 'POST',
+    json: {
+      workspaceId,
+      keyword: 'searchable',
+      limit: 2,
+    },
+  }).json()
+  const srs2 = completionRes2.results.searchResults
+  const blocks2 = completionRes2.results.blocks
+  t.is(srs2.length, 2)
+  // all of them are metric blocks
+  t.is(blocks2[srs2[0]].type, 'metric')
+  t.is(blocks2[srs2[1]].type, 'metric')
+
+  await getRepository(BlockEntity).delete([qid, mid1, mid2])
 })


### PR DESCRIPTION
- metric blocks return first, followed by question blocks
- tfter that, if you need to add `dbt block`, just add it [here](https://github.com/tellery/tellery/pull/199/files#diff-62d18bc5656dd3ea0525404ed0a4b7600bad8f2619ea6e8a3be737840147b80fR161)

Firstly, the implementation of simple version is written, which is realized by querying from the database many times