### PR TITLE
refactor(connector): use sealed class to replace hacky Either usage

### DIFF
--- a/packages/connector/gradle.properties
+++ b/packages/connector/gradle.properties
@@ -5,7 +5,6 @@ coroutinesVersion=1.4.2
 protobufVersion=3.9.0
 krotoplusVersion=0.6.1
 grpcVersion=1.39.0
-arrowVersion=0.13.2
 #its version corresponds to grpc version, check [Here](https://github.com/grpc/grpc-java/blob/master/SECURITY.md)
 nattytcnativeVersion=2.0.34.Final
 jacksonVersion=2.12.2

--- a/packages/connector/interface/build.gradle.kts
+++ b/packages/connector/interface/build.gradle.kts
@@ -1,7 +1,6 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val coroutinesVersion: String by project
-val arrowVersion: String by project
 val logbackVersion: String by project
 val grpcVersion: String by project
 
@@ -10,7 +9,6 @@ val snapshotVersion = "0.8.0"
 
 repositories {
     jcenter()
-    maven("https://dl.bintray.com/arrow-kt/arrow-kt/")
     maven("https://kotlin.bintray.com/kotlinx")
 }
 
@@ -18,7 +16,6 @@ plugins {
     idea
     `java-library`
     kotlin("jvm")
-    kotlin("kapt")
     `maven-publish`
 }
 
@@ -40,9 +37,6 @@ dependencies {
     api("ch.qos.logback:logback-classic:$logbackVersion")
     api("io.github.microutils:kotlin-logging:2.0.10")
     api("javax.annotation:javax.annotation-api:1.3.2")
-
-    api("io.arrow-kt:arrow-core:$arrowVersion")
-    kapt("io.arrow-kt:arrow-meta:$arrowVersion")
 
     api("io.grpc:grpc-stub:$grpcVersion")
 

--- a/packages/connector/interface/src/annotations/Dbt.kt
+++ b/packages/connector/interface/src/annotations/Dbt.kt
@@ -29,4 +29,10 @@ annotation class Dbt(
             required = false
         )
     ]
-)
+) {
+    object DbtFields {
+        const val GIT_URL = "Git Url"
+        const val DBT_PROJECT_NAME = "Dbt Project Name"
+        const val PUBLIC_KEY = "Public Key"
+    }
+}

--- a/packages/connector/interface/src/annotations/DbtFields.kt
+++ b/packages/connector/interface/src/annotations/DbtFields.kt
@@ -1,7 +1,0 @@
-package io.tellery.connectors.annotations
-
-object DbtFields {
-    const val GIT_URL = "Git Url"
-    const val DBT_PROJECT_NAME = "Dbt Project Name"
-    const val PUBLIC_KEY = "Public Key"
-}

--- a/packages/connector/interface/src/entities/CollectionField.kt
+++ b/packages/connector/interface/src/entities/CollectionField.kt
@@ -1,3 +1,0 @@
-package io.tellery.entities
-
-data class CollectionField(val collection: String, val schema: String?)

--- a/packages/connector/interface/src/entities/QueryContext.kt
+++ b/packages/connector/interface/src/entities/QueryContext.kt
@@ -1,8 +1,0 @@
-package io.tellery.entities
-
-data class QueryContext(
-    val sql: String,
-    val questionId: String?,
-    val maxRows: Int,
-)
-

--- a/packages/connector/interface/src/entities/QueryRelated.kt
+++ b/packages/connector/interface/src/entities/QueryRelated.kt
@@ -1,0 +1,19 @@
+package io.tellery.entities
+
+data class QueryContext(
+    val sql: String,
+    val questionId: String?,
+    val maxRows: Int,
+)
+
+data class TypeField(val name: String, val type: Int)
+
+data class CollectionField(val collection: String, val schema: String?)
+
+sealed class QueryResultSet {
+    class Fields(val value: List<TypeField>) : QueryResultSet()
+    class Rows(val value: List<Any>) : QueryResultSet()
+    class Error(val value: Exception) : QueryResultSet()
+}
+
+typealias ImportHandler = suspend (database: String, collection: String, schema: String?, content: ByteArray) -> Unit

--- a/packages/connector/interface/src/entities/TypeAlias.kt
+++ b/packages/connector/interface/src/entities/TypeAlias.kt
@@ -1,7 +1,0 @@
-package io.tellery.entities
-
-import arrow.core.Either
-
-
-typealias QueryResultWrapper = Either<List<TypeField>, List<Any>>
-typealias ImportHandler = suspend (database: String, collection: String, schema: String?, content: ByteArray) -> Unit

--- a/packages/connector/interface/src/entities/TypeField.kt
+++ b/packages/connector/interface/src/entities/TypeField.kt
@@ -1,3 +1,0 @@
-package io.tellery.entities
-
-data class TypeField(val name: String, val type: Int)

--- a/packages/connector/interface/src/interfaces/IConnector.kt
+++ b/packages/connector/interface/src/interfaces/IConnector.kt
@@ -26,7 +26,7 @@ interface IConnector {
         schemaName: String?,
     ): List<TypeField>
 
-    suspend fun query(ctx: QueryContext, sendToChannel: suspend (QueryResultWrapper) -> Unit)
+    suspend fun query(ctx: QueryContext, sendToChannel: suspend (QueryResultSet) -> Unit)
 
     suspend fun import(
         database: String,
@@ -38,7 +38,8 @@ interface IConnector {
         val (_, response, result) = Fuel.get(url).awaitByteArrayResponseResult()
         result.fold(success = { content ->
             val contentType = response.header("Content-Type").single()
-            val handler = importDispatcher[contentType] ?: throw ImportNotSupportedException(contentType)
+            val handler =
+                importDispatcher[contentType] ?: throw ImportNotSupportedException(contentType)
             handler(database, collection, schema, content)
         }, failure = { error ->
             logger.error { error }

--- a/packages/connector/server/src/services/ConnectorService.kt
+++ b/packages/connector/server/src/services/ConnectorService.kt
@@ -1,6 +1,5 @@
 package io.tellery.services
 
-import arrow.core.Either
 import com.google.gson.GsonBuilder
 import com.google.protobuf.ByteString
 import com.google.protobuf.Empty
@@ -215,13 +214,13 @@ class ConnectorService : ConnectorCoroutineGrpc.ConnectorImplBase() {
         request: SubmitQueryRequest,
         responseChannel: SendChannel<QueryResult>
     ) {
-        val currentQueryChannel = Channel<Either<Exception, QueryResultWrapper>>()
+        val currentQueryChannel = Channel<QueryResultSet>()
         val queryContext = QueryContext(request.sql, request.questionId, request.maxRow)
         val connector = ConnectorManager.getDBConnector(request.profile)
         connector.queryWithLimit(queryContext, currentQueryChannel)
         currentQueryChannel.consumeEach { cursor ->
             when (cursor) {
-                is Either.Left -> {
+                is QueryResultSet.Error -> {
                     when (cursor.value) {
                         is TruncateException -> {
                             responseChannel.send(QueryResult {
@@ -231,27 +230,23 @@ class ConnectorService : ConnectorCoroutineGrpc.ConnectorImplBase() {
                         else -> throw errorWrapper(cursor.value, "query")
                     }
                 }
-                is Either.Right -> {
-                    when (val content = cursor.value) {
-                        is Either.Left -> {
-                            responseChannel.send(QueryResult {
-                                fields {
-                                    addAllFields(content.value.map {
-                                        SchemaField {
-                                            name = it.name
-                                            displayType = toDisplayType(it.type)
-                                            sqlType = SQLType.forNumber(it.type)
-                                        }
-                                    })
+                is QueryResultSet.Fields -> {
+                    responseChannel.send(QueryResult {
+                        fields {
+                            addAllFields(cursor.value.map {
+                                SchemaField {
+                                    name = it.name
+                                    displayType = toDisplayType(it.type)
+                                    sqlType = SQLType.forNumber(it.type)
                                 }
                             })
                         }
-                        is Either.Right -> {
-                            responseChannel.send(QueryResult {
-                                row = ByteString.copyFrom(serializer.toJson(content.value), UTF_8)
-                            })
-                        }
-                    }
+                    })
+                }
+                is QueryResultSet.Rows -> {
+                    responseChannel.send(QueryResult {
+                        row = ByteString.copyFrom(serializer.toJson(cursor.value), UTF_8)
+                    })
                 }
             }
         }


### PR DESCRIPTION
#### What type of PR is this?

- cleanup


#### What this PR does / why we need it:
- use sealed class to replace hacky Either usage, therefore removed arrow and kapt usage
- polished file structure, merged related classes & objects to a single file

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
None