### PR TITLE
fix(connector): get profile throw NPE while the profile hasn't be created

### DIFF
--- a/packages/connector/server/src/services/ProfileService.kt
+++ b/packages/connector/server/src/services/ProfileService.kt
@@ -1,12 +1,14 @@
 package io.tellery.services
 
 import com.google.protobuf.Empty
+import io.grpc.Status
 import io.tellery.annotations.Config
 import io.tellery.base.KVEntry
 import io.tellery.common.withErrorWrapper
 import io.tellery.configs.AvailableConfig
 import io.tellery.configs.AvailableConfigs
 import io.tellery.configs.ConfigField
+import io.tellery.entities.CustomizedException
 import io.tellery.entities.IntegrationEntity
 import io.tellery.entities.ProfileEntity
 import io.tellery.managers.ConnectorManager
@@ -41,7 +43,8 @@ class ProfileService(
     override suspend fun getProfile(request: Empty): Profile {
         return withErrorWrapper {
             val profile = profileManager.getProfileById(config.workspaceId)
-            buildProtoProfile(profile!!)
+                ?: throw CustomizedException("The profile hasn't be created.", Status.NOT_FOUND)
+            buildProtoProfile(profile)
         }
     }
 


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

get profile throw NPE while the profile hasn't be created

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
