### PR TITLE
fix: move sql error body into grpc body instead of metadata 

### DIFF
--- a/packages/api/src/clients/connector/fake.ts
+++ b/packages/api/src/clients/connector/fake.ts
@@ -24,12 +24,8 @@ export class FakeManager implements IConnectorManager {
     throw new Error('Method not implemented.')
   }
 
-  async getProfile(): Promise<Profile> {
-    return {
-      id: 'fake',
-      type: 'fake',
-      configs: {},
-    }
+  async getProfile(): Promise<Profile | undefined> {
+    return undefined
   }
 
   async upsertProfile(newProfile: Profile): Promise<Profile> {

--- a/packages/api/src/clients/connector/interface.ts
+++ b/packages/api/src/clients/connector/interface.ts
@@ -19,7 +19,7 @@ export interface IConnectorManager {
 
   getProfileSpec(): Promise<ProfileSpec>
 
-  getProfile(): Promise<Profile>
+  getProfile(): Promise<Profile | undefined>
 
   upsertProfile(profileBody: Profile): Promise<Profile>
 

--- a/packages/api/src/core/block/index.ts
+++ b/packages/api/src/core/block/index.ts
@@ -44,7 +44,7 @@ export function getBlockConstructor(type: BlockType): BlockConstructor {
   const c = constructs[type]
 
   if (!c) {
-    throw InvalidArgumentError.new('unknown block type')
+    throw InvalidArgumentError.new(`unknown block type: ${type}`)
   }
   return c
 }

--- a/packages/api/src/services/connector.ts
+++ b/packages/api/src/services/connector.ts
@@ -34,7 +34,7 @@ export class ConnectorService {
     await canUpdateWorkspaceData(this.permission, operatorId, workspaceId)
 
     const manager = getManager(request)
-    await manager.getProfileConfigs()
+    await manager.getProfile()
 
     const entity = new ConnectorEntity()
     entity.url = request.url
@@ -91,7 +91,7 @@ export class ConnectorService {
     connectorManager: IConnectorManager,
     operatorId: string,
     workspaceId: string,
-  ): Promise<Profile> {
+  ): Promise<Profile | undefined> {
     await canGetWorkspaceData(this.permission, operatorId, workspaceId)
 
     return connectorManager.getProfile()

--- a/packages/api/src/utils/grpc.ts
+++ b/packages/api/src/utils/grpc.ts
@@ -24,7 +24,18 @@ export function beautyCall<ReqT, RespT>(
       if (errCount < 3 && e.code && e.code === grpc.status.UNAVAILABLE) {
         return beautyCall(func, client, request, metadata, options, errCount + 1)
       }
-      throw createError(e.code === 2 ? 500 : 400, {
+      let code: number
+      switch (e.code) {
+        case grpc.status.UNKNOWN:
+          code = 500
+          break
+        case grpc.status.NOT_FOUND:
+          code = 404
+          break
+        default:
+          code = 400
+      }
+      throw createError(code, {
         upstreamErr: errorResponse(e.details).errMsg,
         errMsg: e.message,
       })

--- a/packages/connector/server/src/Main.kt
+++ b/packages/connector/server/src/Main.kt
@@ -39,7 +39,6 @@ fun providesProfileManager(): ProfileManager? =
     when (ProjectConfig.deployMode) {
         ProjectConfig.DeployMode.LOCAL -> FileProfileManager()
         ProjectConfig.DeployMode.CLUSTER -> DatabaseProfileManager()
-        else -> null
     }
 
 @OptIn(KoinApiExtension::class)

--- a/packages/connector/server/src/services/ConnectorService.kt
+++ b/packages/connector/server/src/services/ConnectorService.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.channels.consumeEach
 import java.nio.charset.StandardCharsets
 import java.sql.Date
+import java.sql.SQLException
 import java.sql.Time
 import java.sql.Timestamp
 
@@ -96,6 +97,11 @@ class ConnectorService(private val connectorManager: ConnectorManager) :
                         is TruncateException -> {
                             responseChannel.send(QueryResult {
                                 truncated = true
+                            })
+                        }
+                        is SQLException -> {
+                            responseChannel.send(QueryResult {
+                                error = cursor.value.message
                             })
                         }
                         else -> throw errorWrapper(cursor.value, "query")

--- a/packages/connector/server/src/services/RpcService.kt
+++ b/packages/connector/server/src/services/RpcService.kt
@@ -20,7 +20,8 @@ class RpcService(
     }
 
     init {
-        var partialBuilder = ServerBuilder.forPort(config.port)
+        var partialBuilder = ServerBuilder
+            .forPort(config.port)
 
         if (config.credCertPath != null && config.credKeyPath != null) {
             try {

--- a/packages/protobufs/connector.proto
+++ b/packages/protobufs/connector.proto
@@ -70,6 +70,7 @@ message QueryResult {
     Schema fields = 1;
     bytes row = 2;
     bool truncated = 3;
+    string error = 4;
   }
 }
 


### PR DESCRIPTION
to avoid 8k header overload; fix getProfile


#### What type of PR is this?

- bug

#### What this PR does / why we need it:
Recently ppl shows me that in some cases `executeSql` would get `13 INTERNAL: Received RST_STREAM with error code 1`.

Investigating this issue, I found it was caused by the long sql execution error, which will be catched and returned as the grpcException and transferred by grpc Metadata that cannot be larger than 8k.

We decided to put the executing error into protobuf body instead of metadata.


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

