### PR TITLE
feat: improve import from file to data warehouse

### DIFF
--- a/packages/api/src/clients/connector/fake.ts
+++ b/packages/api/src/clients/connector/fake.ts
@@ -72,8 +72,21 @@ export class FakeManager implements IConnectorManager {
     throw new Error('Method not implemented.')
   }
 
-  async importFromFile(
+  async importFromUrl(
     _url: string,
+    _database: string,
+    _collection: string,
+    _schema?: string,
+  ): Promise<{ database: string; collection: string }> {
+    return {
+      database: '',
+      collection: '',
+    }
+  }
+
+  async importFromFile(
+    _fileBody: Buffer,
+    _contentType: string,
     _database: string,
     _collection: string,
     _schema?: string,

--- a/packages/api/src/clients/connector/interface.ts
+++ b/packages/api/src/clients/connector/interface.ts
@@ -68,8 +68,23 @@ export interface IConnectorManager {
    * @param database
    * @param schema
    */
-  importFromFile(
+  importFromUrl(
     url: string,
+    database: string,
+    collection: string,
+    schema?: string,
+  ): Promise<{ database: string; collection: string }>
+
+  /**
+   * import a file from its body to the data warehouse by connector
+   * use when importFromUrl fails
+   * @param url
+   * @param database
+   * @param schema
+   */
+  importFromFile(
+    fileBody: Buffer,
+    contentType: string,
     database: string,
     collection: string,
     schema?: string,

--- a/packages/api/src/routes/connector.ts
+++ b/packages/api/src/routes/connector.ts
@@ -498,19 +498,11 @@ async function importFromFile(ctx: Context) {
 
   const manager = await getIConnectorManagerFromDB(workspaceId, connectorId)
 
-  const { body: correspondingUrl } = await storageService.objectProxy(user.id, workspaceId, key, {
-    skipPermissionCheck: true,
-    acquireUrlOnly: true,
-  })
-  if (!correspondingUrl) {
-    throw StorageError.notSupportImport()
-  }
-
   const result = await connectorService.importFromFile(
     manager,
     user.id,
     workspaceId,
-    correspondingUrl as string,
+    key,
     database,
     collection,
     schema,

--- a/packages/connector/interface/src/interfaces/IConnector.kt
+++ b/packages/connector/interface/src/interfaces/IConnector.kt
@@ -1,7 +1,5 @@
 package io.tellery.interfaces
 
-import com.github.kittinunf.fuel.Fuel
-import com.github.kittinunf.fuel.coroutines.awaitByteArrayResponseResult
 import io.tellery.entities.*
 import mu.KLogger
 
@@ -32,19 +30,9 @@ interface IConnector {
         database: String,
         collection: String,
         schema: String?,
-        url: String,
-    ) {
-        importSanityCheck(database, collection, schema)
-        val (_, response, result) = Fuel.get(url).awaitByteArrayResponseResult()
-        result.fold(success = { content ->
-            val contentType = response.header("Content-Type").single()
-            val handler =
-                importDispatcher[contentType] ?: throw ImportNotSupportedException(contentType)
-            handler(database, collection, schema, content)
-        }, failure = { error ->
-            logger.error { error }
-            throw DownloadFailedException()
-        })
-    }
+        contentType: String,
+        body: ByteArray
+    )
+
 }
 

--- a/packages/connector/server/src/services/ConnectorService.kt
+++ b/packages/connector/server/src/services/ConnectorService.kt
@@ -132,7 +132,7 @@ class ConnectorService(private val connectorManager: ConnectorManager) :
         }
     }
 
-    override suspend fun importFromFile(request: ImportRequest): ImportResult {
+    override suspend fun importFromUrl(request: ImportUrlRequest): ImportResult {
         return withErrorWrapper {
             val connector = connectorManager.getConnector()
 
@@ -141,6 +141,26 @@ class ConnectorService(private val connectorManager: ConnectorManager) :
                 request.collection,
                 request.schema.ifBlank { null },
                 request.url
+            )
+
+            ImportResult {
+                database = request.database
+                collection = request.collection
+                if (request.schema.isNotBlank()) schema = request.schema
+            }
+        }
+    }
+
+    override suspend fun importFromFile(request: ImportFileRequest): ImportResult {
+        return withErrorWrapper {
+            val connector = connectorManager.getConnector()
+
+            connector.import(
+                request.database,
+                request.collection,
+                request.schema.ifBlank { null },
+                request.contentType,
+                request.fileBodyBytes.toByteArray()
             )
 
             ImportResult {

--- a/packages/protobufs/connector.proto
+++ b/packages/protobufs/connector.proto
@@ -14,7 +14,8 @@ service ConnectorService {
   rpc GetCollections (GetCollectionRequest) returns (Collections);
   rpc GetCollectionSchema (GetCollectionSchemaRequest) returns (Schema);
   rpc Query (SubmitQueryRequest) returns (stream QueryResult);
-  rpc ImportFromFile (ImportRequest) returns (ImportResult);
+  rpc ImportFromUrl (ImportUrlRequest) returns (ImportResult);
+  rpc ImportFromFile (ImportFileRequest) returns (ImportResult);
 }
 
 message GetCollectionRequest {
@@ -33,11 +34,19 @@ message SubmitQueryRequest {
   int32 maxRow = 3;
 }
 
-message ImportRequest {
+message ImportUrlRequest {
   string database = 1;
   string collection = 2;
   string schema = 3;
   string url = 4;
+}
+
+message ImportFileRequest {
+  string database = 1;
+  string collection = 2;
+  string schema = 3;
+  string contentType = 4;
+  string fileBody = 5;
 }
 
 message SchemaField {


### PR DESCRIPTION
#### What type of PR is this?
- feature

#### What this PR does / why we need it:
In the beginning of our design, importing (csv) from file would send the url of the uploaded file, and the connector service would download it from object storage (S3 for instance).

Such an implementation will cost less on the network transferring, especially in the case of self-deployed connector.

But for self-hosted deployment, asking for a object storage is unreasonable in some cases, so we provided a postgres-based self hosted storage. In such a case, it will be better to transfer the file body to the connector when importing a file.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
None
