### PR TITLE
fix(translator): now only the limit will be only added to select clause

### DIFF
--- a/packages/api/tests/core/translator/index.test.ts
+++ b/packages/api/tests/core/translator/index.test.ts
@@ -201,8 +201,11 @@ test('withLimit', async (t) => {
   stringCompare(t, await translate(sql2, {}, 10), 'select * from test LIMIT 10')
 
   const sql3 = 'select * from test limit 20'
-  stringCompare(t, await translate(sql3, {}, 10), 'select * from test limit 20')
+  stringCompare(t, await translate(sql3, {}), sql3)
 
   const sql4 = 'select * from test LIMIT 20'
-  stringCompare(t, await translate(sql4, {}, 10), 'select * from test LIMIT 20')
+  stringCompare(t, await translate(sql4, {}), sql4)
+
+  const sql5 = 'desc table1'
+  stringCompare(t, await translate(sql5, {}), sql5)
 })


### PR DESCRIPTION
#### What type of PR is this?
- bug

#### What this PR does / why we need it:
Previously we introduced `withLimit` to automatically add limit part into SQL query to reduce the calculation happened in the data warehouse, but it will be also added to `desc`.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
None
