### PR TITLE
feat: skip permission check when saving transaction

### DIFF
--- a/packages/api/src/core/operation/index.ts
+++ b/packages/api/src/core/operation/index.ts
@@ -28,7 +28,7 @@ export class OperationManager {
 
   operator: string
 
-  permission: IPermission
+  permission: IPermission | null
 
   operation: IOperation
 
@@ -50,7 +50,7 @@ export class OperationManager {
     operator: string,
     table: OperationTableType,
     manager: EntityManager,
-    permission: IPermission,
+    permission: IPermission | null,
     activityService: ActivitySyncService,
   ) {
     this.id = id
@@ -77,7 +77,9 @@ export class OperationManager {
   }
 
   async end(): Promise<void> {
-    await this.operation.checkPermission(this.permission, this.entity, this._origin)
+    if (this.permission) {
+      await this.operation.checkPermission(this.permission, this.entity, this._origin)
+    }
     await this.operation.save(this.entity, this._origin)
     // record the operation
     const before = this._origin

--- a/packages/api/src/services/block.ts
+++ b/packages/api/src/services/block.ts
@@ -227,6 +227,7 @@ export class BlockService {
           operations,
         }))
         .value(),
+      { skipPermissionCheck: true },
     )
     if (!_.isEmpty(failures)) {
       throw failures[0].error

--- a/packages/api/src/services/operation.ts
+++ b/packages/api/src/services/operation.ts
@@ -31,7 +31,9 @@ export class OperationService {
     operatorId: string,
     workspaceId: string,
     data: SingleOperation[],
+    opts: { skipPermissionCheck?: boolean } = {},
   ): Promise<void> {
+    const { skipPermissionCheck = false } = opts
     return getManager().transaction(async (t) => {
       const cache: { [k: string]: OperationManager } = {}
       await bluebird.each(data, async (val) => {
@@ -44,7 +46,7 @@ export class OperationService {
               operatorId,
               val.table,
               t,
-              this.permission,
+              !skipPermissionCheck ? this.permission : null,
               this.activityService,
             )
             cache[val.id] = m
@@ -66,6 +68,7 @@ export class OperationService {
   async saveTransactions(
     operatorId: string,
     data: { id: string; workspaceId: string; operations: SingleOperation[] }[],
+    opts: { skipPermissionCheck?: boolean } = {},
   ): Promise<{ error: Error; transactionId: string }[]> {
     const res: { error: Error; transactionId: string }[] = []
     const successes: { id: string; workspaceId: string; operations: SingleOperation[] }[] = []
@@ -76,6 +79,7 @@ export class OperationService {
           operatorId,
           transaction.workspaceId,
           transaction.operations,
+          opts,
         )
         successes.push(transaction)
       } catch (error: unknown) {


### PR DESCRIPTION
#### What type of PR is this?
- feature

#### What this PR does / why we need it:
This is a workaround for downgrading query builder.
When a query builder was downgraded, the smart queries of its downstream would be transferred to regular SQL queries immediately, and this should be down by saving transactions for automatically sending notifications by broadcasting.
In this case, the permission check of the modification on its downstream can be skipped because they are smart queries; that is, they are formed depending on the query builder itself. Once one gets permission to modify the query builder, one can always influence its downstream. On the other hand, the data retrieved from those smart queries won't be affected since it trustily translated itself into SQL queries.

Use this feature (workaround) only if you are sure that the privilege elevation is always harmless.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
None
