### PR TITLE
chore: add configuration of keepAlive timeout for server

### DIFF
--- a/packages/api/config/default.js
+++ b/packages/api/config/default.js
@@ -38,6 +38,7 @@ module.exports = {
     protocol: process.env.SERVER_PROTO || 'http',
     webPort: process.env.SERVER_WEB_PORT || 80,
     port: process.env.SERVER_PORT || 8000,
+    keepAliveTimeout: process.env.SERVER_KEEP_ALIVE_TIMEOUT || 60 * 1000,
   },
   // for SaaS usage
   deploy: {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -55,6 +55,7 @@ const app = new Koa()
 app.proxy = true
 
 const server = createServer(app.callback())
+server.keepAliveTimeout = config.get<number>('server.keepAliveTimeout')
 
 if (!config.has('socket.url')) {
   initSocketServer(server)


### PR DESCRIPTION
#### What type of PR is this?

- feature

#### What this PR does / why we need it:
Fixes the issue of the `idleTimeout` in envoy being way longer than `keepAliveTimeout` in the client, where race condition met in our infrastructure.

The default `keepAliveTimeout` will be set to 1mins to align with envoy.

#### Which issue(s) this PR fixes:
NONE

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
